### PR TITLE
Refine API for interned labels

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -777,14 +777,12 @@ impl App {
 
     /// Inserts an existing sub app into the app
     pub fn insert_sub_app(&mut self, label: impl AppLabel, sub_app: SubApp) {
-        self.sub_apps
-            .insert(label.intern(), sub_app);
+        self.sub_apps.insert(label.intern(), sub_app);
     }
 
     /// Removes a sub app from the app. Returns [`None`] if the label doesn't exist.
     pub fn remove_sub_app(&mut self, label: impl AppLabel) -> Option<SubApp> {
-        self.sub_apps
-            .remove(&label.intern())
+        self.sub_apps.remove(&label.intern())
     }
 
     /// Retrieves a `SubApp` inside this [`App`] with the given label, if it exists. Otherwise returns

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -158,7 +158,7 @@ impl SubApp {
 
     /// Runs the [`SubApp`]'s default schedule.
     pub fn run(&mut self) {
-        self.app.world.run_schedule(&*self.app.main_schedule_label);
+        self.app.world.run_schedule(self.app.main_schedule_label);
         self.app.world.clear_trackers();
     }
 
@@ -221,7 +221,7 @@ impl App {
             sub_apps: HashMap::default(),
             plugin_registry: Vec::default(),
             plugin_name_added: Default::default(),
-            main_schedule_label: Main.into(),
+            main_schedule_label: Main.intern(),
             building_plugin_depth: 0,
         }
     }
@@ -243,7 +243,7 @@ impl App {
         {
             #[cfg(feature = "trace")]
             let _bevy_main_update_span = info_span!("main app").entered();
-            self.world.run_schedule(&*self.main_schedule_label);
+            self.world.run_schedule(self.main_schedule_label);
         }
         for (_label, sub_app) in self.sub_apps.iter_mut() {
             #[cfg(feature = "trace")]
@@ -381,7 +381,7 @@ impl App {
         schedule: impl ScheduleLabel,
         systems: impl IntoSystemConfigs<M>,
     ) -> &mut Self {
-        let schedule = InternedScheduleLabel::from(&schedule as &dyn ScheduleLabel);
+        let schedule = schedule.intern();
         let mut schedules = self.world.resource_mut::<Schedules>();
 
         if let Some(schedule) = schedules.get_mut(schedule) {
@@ -401,7 +401,7 @@ impl App {
         schedule: impl ScheduleLabel,
         set: impl IntoSystemSetConfig,
     ) -> &mut Self {
-        let schedule = InternedScheduleLabel::from(&schedule as &dyn ScheduleLabel);
+        let schedule = schedule.intern();
         let mut schedules = self.world.resource_mut::<Schedules>();
         if let Some(schedule) = schedules.get_mut(schedule) {
             schedule.configure_set(set);
@@ -419,7 +419,7 @@ impl App {
         schedule: impl ScheduleLabel,
         sets: impl IntoSystemSetConfigs,
     ) -> &mut Self {
-        let schedule = InternedScheduleLabel::from(&schedule as &dyn ScheduleLabel);
+        let schedule = schedule.intern();
         let mut schedules = self.world.resource_mut::<Schedules>();
         if let Some(schedule) = schedules.get_mut(schedule) {
             schedule.configure_sets(sets);
@@ -758,7 +758,7 @@ impl App {
     /// an [`Err`] containing the given label.
     pub fn get_sub_app_mut(&mut self, label: impl AppLabel) -> Result<&mut App, impl AppLabel> {
         self.sub_apps
-            .get_mut(&InternedAppLabel::from(&label as &dyn AppLabel))
+            .get_mut(&label.intern())
             .map(|sub_app| &mut sub_app.app)
             .ok_or(label)
     }
@@ -778,20 +778,20 @@ impl App {
     /// Inserts an existing sub app into the app
     pub fn insert_sub_app(&mut self, label: impl AppLabel, sub_app: SubApp) {
         self.sub_apps
-            .insert((&label as &dyn AppLabel).into(), sub_app);
+            .insert(label.intern(), sub_app);
     }
 
     /// Removes a sub app from the app. Returns [`None`] if the label doesn't exist.
     pub fn remove_sub_app(&mut self, label: impl AppLabel) -> Option<SubApp> {
         self.sub_apps
-            .remove(&InternedAppLabel::from(&label as &dyn AppLabel))
+            .remove(&label.intern())
     }
 
     /// Retrieves a `SubApp` inside this [`App`] with the given label, if it exists. Otherwise returns
     /// an [`Err`] containing the given label.
     pub fn get_sub_app(&self, label: impl AppLabel) -> Result<&App, impl AppLabel> {
         self.sub_apps
-            .get(&InternedAppLabel::from(&label as &dyn AppLabel))
+            .get(&label.intern())
             .map(|sub_app| &sub_app.app)
             .ok_or(label)
     }
@@ -803,7 +803,7 @@ impl App {
     /// To avoid this behavior, use the `init_schedule` method instead.
     pub fn add_schedule(&mut self, label: impl ScheduleLabel, schedule: Schedule) -> &mut Self {
         let mut schedules = self.world.resource_mut::<Schedules>();
-        schedules.insert(&label as &dyn ScheduleLabel, schedule);
+        schedules.insert(label, schedule);
 
         self
     }
@@ -812,7 +812,7 @@ impl App {
     ///
     /// See [`App::add_schedule`] to pass in a pre-constructed schedule.
     pub fn init_schedule(&mut self, label: impl ScheduleLabel) -> &mut Self {
-        let label = InternedScheduleLabel::from(&label as &dyn ScheduleLabel);
+        let label = label.intern();
         let mut schedules = self.world.resource_mut::<Schedules>();
         if !schedules.contains(label) {
             schedules.insert(label, Schedule::new());
@@ -823,7 +823,7 @@ impl App {
     /// Gets read-only access to the [`Schedule`] with the provided `label` if it exists.
     pub fn get_schedule(&self, label: impl ScheduleLabel) -> Option<&Schedule> {
         let schedules = self.world.get_resource::<Schedules>()?;
-        schedules.get(&label as &dyn ScheduleLabel)
+        schedules.get(label)
     }
 
     /// Gets read-write access to a [`Schedule`] with the provided `label` if it exists.
@@ -831,7 +831,7 @@ impl App {
         let schedules = self.world.get_resource_mut::<Schedules>()?;
         // We need to call .into_inner here to satisfy the borrow checker:
         // it can reason about reborrows using ordinary references but not the `Mut` smart pointer.
-        schedules.into_inner().get_mut(&label as &dyn ScheduleLabel)
+        schedules.into_inner().get_mut(label)
     }
 
     /// Applies the function to the [`Schedule`] associated with `label`.
@@ -842,7 +842,7 @@ impl App {
         label: impl ScheduleLabel,
         f: impl FnOnce(&mut Schedule),
     ) -> &mut Self {
-        let label = InternedScheduleLabel::from(&label as &dyn ScheduleLabel);
+        let label = label.intern();
         let mut schedules = self.world.resource_mut::<Schedules>();
 
         if schedules.get(label).is_none() {

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -1,6 +1,6 @@
 use crate::{App, Plugin};
 use bevy_ecs::{
-    schedule::{ExecutorKind, Schedule, ScheduleLabel, InternedScheduleLabel},
+    schedule::{ExecutorKind, InternedScheduleLabel, Schedule, ScheduleLabel},
     system::{Local, Resource},
     world::{Mut, World},
 };

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -1,6 +1,6 @@
 use crate::{App, Plugin};
 use bevy_ecs::{
-    schedule::{ExecutorKind, Schedule, ScheduleLabel},
+    schedule::{ExecutorKind, Schedule, ScheduleLabel, InternedScheduleLabel},
     system::{Local, Resource},
     world::{Mut, World},
 };
@@ -100,20 +100,20 @@ pub struct Last;
 #[derive(Resource, Debug)]
 pub struct MainScheduleOrder {
     /// The labels to run for the [`Main`] schedule (in the order they will be run).
-    pub labels: Vec<Box<dyn ScheduleLabel>>,
+    pub labels: Vec<InternedScheduleLabel>,
 }
 
 impl Default for MainScheduleOrder {
     fn default() -> Self {
         Self {
             labels: vec![
-                Box::new(First),
-                Box::new(PreUpdate),
-                Box::new(StateTransition),
-                Box::new(RunFixedUpdateLoop),
-                Box::new(Update),
-                Box::new(PostUpdate),
-                Box::new(Last),
+                First.intern(),
+                PreUpdate.intern(),
+                StateTransition.intern(),
+                RunFixedUpdateLoop.intern(),
+                Update.intern(),
+                PostUpdate.intern(),
+                Last.intern(),
             ],
         }
     }
@@ -127,7 +127,7 @@ impl MainScheduleOrder {
             .iter()
             .position(|current| (**current).eq(&after))
             .unwrap_or_else(|| panic!("Expected {after:?} to exist"));
-        self.labels.insert(index + 1, Box::new(schedule));
+        self.labels.insert(index + 1, schedule.intern());
     }
 }
 
@@ -142,8 +142,8 @@ impl Main {
         }
 
         world.resource_scope(|world, order: Mut<MainScheduleOrder>| {
-            for label in &order.labels {
-                let _ = world.try_run_schedule(&**label);
+            for &label in &order.labels {
+                let _ = world.try_run_schedule(label);
             }
         });
     }

--- a/crates/bevy_ecs/macros/src/set.rs
+++ b/crates/bevy_ecs/macros/src/set.rs
@@ -1,3 +1,4 @@
+use bevy_macro_utils::BevyManifest;
 use proc_macro::TokenStream;
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
@@ -9,6 +10,8 @@ use syn::spanned::Spanned;
 /// - `input`: The [`syn::DeriveInput`] for the struct that we want to derive the set trait for
 /// - `trait_path`: The [`syn::Path`] to the set trait
 pub fn derive_set(input: syn::DeriveInput, trait_path: &syn::Path) -> TokenStream {
+    let bevy_utils_path = BevyManifest::default().get_path("bevy_utils");
+
     let ident = input.ident;
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
@@ -67,6 +70,15 @@ pub fn derive_set(input: syn::DeriveInput, trait_path: &syn::Path) -> TokenStrea
         impl #impl_generics #trait_path for #ident #ty_generics #where_clause {
             fn dyn_clone(&self) -> std::boxed::Box<dyn #trait_path> {
                 std::boxed::Box::new(std::clone::Clone::clone(self))
+            }
+
+            fn as_dyn_eq(&self) -> &dyn #bevy_utils_path::label::DynEq {
+                self
+            }
+
+            fn dyn_hash(&self, mut state: &mut dyn ::std::hash::Hasher) {
+                std::hash::Hash::hash(&std::any::TypeId::of::<Self>(), &mut state);
+                std::hash::Hash::hash(self, &mut state);
             }
 
             fn dyn_static_ref(&self) -> std::option::Option<&'static dyn #trait_path> {

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -449,12 +449,6 @@ impl<S: SystemSet> IntoSystemSetConfig for S {
     }
 }
 
-impl IntoSystemSetConfig for InternedSystemSet {
-    fn into_config(self) -> SystemSetConfig {
-        SystemSetConfig::new(self)
-    }
-}
-
 impl IntoSystemSetConfig for SystemSetConfig {
     fn into_config(self) -> Self {
         self

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -307,20 +307,20 @@ impl IntoSystemConfigs<()> for SystemConfigs {
             "adding arbitrary systems to a system type set is not allowed"
         );
 
-        self.in_set_inner((&set as &dyn SystemSet).into());
+        self.in_set_inner(set.intern());
 
         self
     }
 
     fn before<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
         let set = set.into_system_set();
-        self.before_inner((&set as &dyn SystemSet).into());
+        self.before_inner(set.intern());
         self
     }
 
     fn after<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
         let set = set.into_system_set();
-        self.after_inner((&set as &dyn SystemSet).into());
+        self.after_inner(set.intern());
         self
     }
 
@@ -331,7 +331,7 @@ impl IntoSystemConfigs<()> for SystemConfigs {
 
     fn ambiguous_with<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
         let set = set.into_system_set();
-        self.ambiguous_with_inner((&set as &dyn SystemSet).into());
+        self.ambiguous_with_inner(set.intern());
         self
     }
 
@@ -445,7 +445,7 @@ pub trait IntoSystemSetConfig: Sized {
 
 impl<S: SystemSet> IntoSystemSetConfig for S {
     fn into_config(self) -> SystemSetConfig {
-        SystemSetConfig::new((&self as &dyn SystemSet).into())
+        SystemSetConfig::new(self.intern())
     }
 }
 
@@ -460,14 +460,14 @@ impl IntoSystemSetConfig for SystemSetConfig {
             set.system_type().is_none(),
             "adding arbitrary systems to a system type set is not allowed"
         );
-        self.graph_info.sets.push((&set as &dyn SystemSet).into());
+        self.graph_info.sets.push(set.intern());
         self
     }
 
     fn before<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
         self.graph_info.dependencies.push(Dependency::new(
             DependencyKind::Before,
-            (&set.into_system_set() as &dyn SystemSet).into(),
+            set.into_system_set().intern(),
         ));
         self
     }
@@ -475,7 +475,7 @@ impl IntoSystemSetConfig for SystemSetConfig {
     fn after<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
         self.graph_info.dependencies.push(Dependency::new(
             DependencyKind::After,
-            (&set.into_system_set() as &dyn SystemSet).into(),
+            set.into_system_set().intern(),
         ));
         self
     }
@@ -488,7 +488,7 @@ impl IntoSystemSetConfig for SystemSetConfig {
     fn ambiguous_with<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
         ambiguous_with(
             &mut self.graph_info,
-            (&set.into_system_set() as &dyn SystemSet).into(),
+            set.into_system_set().intern(),
         );
         self
     }
@@ -563,14 +563,14 @@ impl IntoSystemSetConfigs for SystemSetConfigs {
             "adding arbitrary systems to a system type set is not allowed"
         );
         for config in &mut self.sets {
-            config.graph_info.sets.push((&set as &dyn SystemSet).into());
+            config.graph_info.sets.push(set.intern());
         }
 
         self
     }
 
     fn before<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        let set = (&set.into_system_set() as &dyn SystemSet).into();
+        let set = set.into_system_set().intern();
         for config in &mut self.sets {
             config
                 .graph_info
@@ -582,7 +582,7 @@ impl IntoSystemSetConfigs for SystemSetConfigs {
     }
 
     fn after<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        let set = (&set.into_system_set() as &dyn SystemSet).into();
+        let set = set.into_system_set().intern();
         for config in &mut self.sets {
             config
                 .graph_info
@@ -594,7 +594,7 @@ impl IntoSystemSetConfigs for SystemSetConfigs {
     }
 
     fn ambiguous_with<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        let set = (&set.into_system_set() as &dyn SystemSet).into();
+        let set = set.into_system_set().intern();
         for config in &mut self.sets {
             ambiguous_with(&mut config.graph_info, set);
         }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -486,10 +486,7 @@ impl IntoSystemSetConfig for SystemSetConfig {
     }
 
     fn ambiguous_with<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        ambiguous_with(
-            &mut self.graph_info,
-            set.into_system_set().intern(),
-        );
+        ambiguous_with(&mut self.graph_info, set.into_system_set().intern());
         self
     }
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -43,38 +43,38 @@ impl Schedules {
     /// and the old schedule is returned. Otherwise, `None` is returned.
     pub fn insert(
         &mut self,
-        label: impl Into<InternedScheduleLabel>,
+        label: impl ScheduleLabel,
         schedule: Schedule,
     ) -> Option<Schedule> {
-        self.inner.insert(label.into(), schedule)
+        self.inner.insert(label.intern(), schedule)
     }
 
     /// Removes the schedule corresponding to the `label` from the map, returning it if it existed.
-    pub fn remove(&mut self, label: impl Into<InternedScheduleLabel>) -> Option<Schedule> {
-        self.inner.remove(&label.into())
+    pub fn remove(&mut self, label: impl ScheduleLabel) -> Option<Schedule> {
+        self.inner.remove(&label.intern ())
     }
 
     /// Removes the (schedule, label) pair corresponding to the `label` from the map, returning it if it existed.
     pub fn remove_entry(
         &mut self,
-        label: impl Into<InternedScheduleLabel>,
+        label: impl ScheduleLabel,
     ) -> Option<(InternedScheduleLabel, Schedule)> {
-        self.inner.remove_entry(&label.into())
+        self.inner.remove_entry(&label.intern())
     }
 
     /// Does a schedule with the provided label already exist?
-    pub fn contains(&self, label: impl Into<InternedScheduleLabel>) -> bool {
-        self.inner.contains_key(&label.into())
+    pub fn contains(&self, label: impl ScheduleLabel) -> bool {
+        self.inner.contains_key(&label.intern())
     }
 
     /// Returns a reference to the schedule associated with `label`, if it exists.
-    pub fn get(&self, label: impl Into<InternedScheduleLabel>) -> Option<&Schedule> {
-        self.inner.get(&label.into())
+    pub fn get(&self, label: impl ScheduleLabel) -> Option<&Schedule> {
+        self.inner.get(&label.intern())
     }
 
     /// Returns a mutable reference to the schedule associated with `label`, if it exists.
-    pub fn get_mut(&mut self, label: impl Into<InternedScheduleLabel>) -> Option<&mut Schedule> {
-        self.inner.get_mut(&label.into())
+    pub fn get_mut(&mut self, label: impl ScheduleLabel) -> Option<&mut Schedule> {
+        self.inner.get_mut(&label.intern())
     }
 
     /// Returns an iterator over all schedules. Iteration order is undefined.
@@ -537,7 +537,7 @@ impl ScheduleGraph {
                     if more_than_one_entry {
                         let set = self.create_anonymous_set();
                         for config in &mut configs {
-                            config.in_set_inner((&set as &dyn SystemSet).into());
+                            config.in_set_inner(set.intern());
                         }
                         let mut set_config = set.into_config();
                         set_config.conditions.extend(collective_conditions);
@@ -721,8 +721,7 @@ impl ScheduleGraph {
         id
     }
 
-    fn check_set(&mut self, id: &NodeId, set: &dyn SystemSet) -> Result<(), ScheduleBuildError> {
-        let set = set.into();
+    fn check_set(&mut self, id: &NodeId, set: InternedSystemSet) -> Result<(), ScheduleBuildError> {
         match self.system_set_ids.get(&set) {
             Some(set_id) => {
                 if id == set_id {
@@ -748,8 +747,8 @@ impl ScheduleGraph {
         id: &NodeId,
         graph_info: &GraphInfo,
     ) -> Result<(), ScheduleBuildError> {
-        for set in &graph_info.sets {
-            self.check_set(id, &**set)?;
+        for &set in &graph_info.sets {
+            self.check_set(id, set)?;
         }
 
         Ok(())

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -41,17 +41,13 @@ impl Schedules {
     ///
     /// If the map already had an entry for `label`, `schedule` is inserted,
     /// and the old schedule is returned. Otherwise, `None` is returned.
-    pub fn insert(
-        &mut self,
-        label: impl ScheduleLabel,
-        schedule: Schedule,
-    ) -> Option<Schedule> {
+    pub fn insert(&mut self, label: impl ScheduleLabel, schedule: Schedule) -> Option<Schedule> {
         self.inner.insert(label.intern(), schedule)
     }
 
     /// Removes the schedule corresponding to the `label` from the map, returning it if it existed.
     pub fn remove(&mut self, label: impl ScheduleLabel) -> Option<Schedule> {
-        self.inner.remove(&label.intern ())
+        self.inner.remove(&label.intern())
     }
 
     /// Removes the (schedule, label) pair corresponding to the `label` from the map, returning it if it existed.

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 
 pub use bevy_ecs_macros::{ScheduleLabel, SystemSet};
 use bevy_utils::define_label;
-use bevy_utils::intern::{Interned, Interner, Leak, StaticRef};
+use bevy_utils::intern::{Interned, Interner, Leak};
 use bevy_utils::label::DynHash;
 
 use crate::system::{
@@ -100,9 +100,7 @@ impl Leak for dyn SystemSet {
     fn leak(&self) -> &'static Self {
         Box::leak(self.dyn_clone())
     }
-}
 
-impl StaticRef for dyn SystemSet {
     fn static_ref(&self) -> Option<&'static dyn SystemSet> {
         self.dyn_static_ref()
     }

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -90,7 +90,7 @@ pub trait SystemSet: Debug + Send + Sync + 'static {
     }
 }
 
-impl SystemSet for Interned<dyn SystemSet> {
+impl SystemSet for InternedSystemSet {
     fn system_type(&self) -> Option<TypeId> {
         (**self).system_type()
     }
@@ -115,10 +115,7 @@ impl SystemSet for Interned<dyn SystemSet> {
         Some(self.0)
     }
 
-    fn intern(&self) -> InternedSystemSet
-    where
-        Self: Sized,
-    {
+    fn intern(&self) -> Self {
         *self
     }
 }

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -76,7 +76,10 @@ pub trait SystemSet: DynHash + Debug + Send + Sync + 'static {
     }
 
     /// Returns an [`InternedSystemSet`] corresponding to `self`.
-    fn intern(&self) -> InternedSystemSet where Self: Sized {
+    fn intern(&self) -> InternedSystemSet
+    where
+        Self: Sized,
+    {
         SYSTEM_SET_INTERNER.intern(self)
     }
 }
@@ -98,7 +101,10 @@ impl SystemSet for Interned<dyn SystemSet> {
         Some(self.0)
     }
 
-    fn intern(&self) -> InternedSystemSet where Self: Sized {
+    fn intern(&self) -> InternedSystemSet
+    where
+        Self: Sized,
+    {
         *self
     }
 }

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -76,6 +76,24 @@ pub trait SystemSet: DynHash + Debug + Send + Sync + 'static {
     }
 }
 
+impl SystemSet for Interned<dyn SystemSet> {
+    fn system_type(&self) -> Option<TypeId> {
+        (**self).system_type()
+    }
+
+    fn is_anonymous(&self) -> bool {
+        (**self).is_anonymous()
+    }
+
+    fn dyn_clone(&self) -> Box<dyn SystemSet> {
+        (**self).dyn_clone()
+    }
+
+    fn dyn_static_ref(&self) -> Option<&'static dyn SystemSet> {
+        Some(self.0)
+    }
+}
+
 impl From<&dyn SystemSet> for Interned<dyn SystemSet> {
     fn from(value: &dyn SystemSet) -> Interned<dyn SystemSet> {
         SYSTEM_SET_INTERNER.intern(value)

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -150,7 +150,7 @@ where
 
     fn default_system_sets(&self) -> Vec<InternedSystemSet> {
         let set = crate::schedule::SystemTypeSet::<F>::new();
-        vec![(&set as &dyn SystemSet).into()]
+        vec![set.intern()]
     }
 }
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -512,7 +512,7 @@ where
 
     fn default_system_sets(&self) -> Vec<InternedSystemSet> {
         let set = crate::schedule::SystemTypeSet::<F>::new();
-        vec![(&set as &dyn SystemSet).into()]
+        vec![set.intern()]
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     event::{Event, Events},
     query::{DebugCheckedUnwrap, QueryState, ReadOnlyWorldQuery, WorldQuery},
     removal_detection::RemovedComponentEvents,
-    schedule::{InternedScheduleLabel, Schedule, ScheduleLabel, Schedules},
+    schedule::{Schedule, ScheduleLabel, Schedules},
     storage::{ResourceData, Storages},
     system::Resource,
     world::error::TryRunScheduleError,
@@ -1750,7 +1750,7 @@ impl World {
     /// The `Schedules` resource will be initialized if it does not already exist.
     pub fn add_schedule(&mut self, schedule: Schedule, label: impl ScheduleLabel) {
         let mut schedules = self.get_resource_or_insert_with(Schedules::default);
-        schedules.insert(&label as &dyn ScheduleLabel, schedule);
+        schedules.insert(label, schedule);
     }
 
     /// Temporarily removes the schedule associated with `label` from the world,
@@ -1766,10 +1766,10 @@ impl World {
     /// For other use cases, see the example on [`World::schedule_scope`].
     pub fn try_schedule_scope<R>(
         &mut self,
-        label: impl Into<InternedScheduleLabel>,
+        label: impl ScheduleLabel,
         f: impl FnOnce(&mut World, &mut Schedule) -> R,
     ) -> Result<R, TryRunScheduleError> {
-        let label = label.into();
+        let label = label.intern();
         let Some((extracted_label, mut schedule))
             = self.get_resource_mut::<Schedules>().and_then(|mut s| s.remove_entry(label))
         else {
@@ -1830,7 +1830,7 @@ impl World {
     /// If the requested schedule does not exist.
     pub fn schedule_scope<R>(
         &mut self,
-        label: impl Into<InternedScheduleLabel>,
+        label: impl ScheduleLabel,
         f: impl FnOnce(&mut World, &mut Schedule) -> R,
     ) -> R {
         self.try_schedule_scope(label, f)
@@ -1846,7 +1846,7 @@ impl World {
     /// For simple testing use cases, call [`Schedule::run(&mut world)`](Schedule::run) instead.
     pub fn try_run_schedule(
         &mut self,
-        label: impl Into<InternedScheduleLabel>,
+        label: impl ScheduleLabel,
     ) -> Result<(), TryRunScheduleError> {
         self.try_schedule_scope(label, |world, sched| sched.run(world))
     }
@@ -1861,7 +1861,7 @@ impl World {
     /// # Panics
     ///
     /// If the requested schedule does not exist.
-    pub fn run_schedule(&mut self, label: impl Into<InternedScheduleLabel>) {
+    pub fn run_schedule(&mut self, label: impl ScheduleLabel) {
         self.schedule_scope(label, |world, sched| sched.run(world));
     }
 }

--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -236,7 +236,7 @@ pub fn derive_label(input: syn::DeriveInput, trait_path: &syn::Path) -> TokenStr
             }
 
             fn dyn_hash(&self, mut state: &mut dyn ::std::hash::Hasher) {
-                let ty_id = #trait_path::inner_type_id(self);
+                let ty_id = ::std::any::TypeId::of::<Self>();
                 ::std::hash::Hash::hash(&ty_id, &mut state);
                 ::std::hash::Hash::hash(self, &mut state);
             }

--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -245,18 +245,6 @@ pub fn derive_label(input: syn::DeriveInput, trait_path: &syn::Path) -> TokenStr
                 #dyn_static_ref_impl
             }
         }
-
-        impl #impl_generics From<#ident #ty_generics> for ::bevy_utils::intern::Interned<dyn #trait_path> #where_clause {
-            fn from(value: #ident #ty_generics) -> Self {
-                (&value as &dyn #trait_path).into()
-            }
-        }
-
-        impl #impl_generics From<& #ident #ty_generics> for ::bevy_utils::intern::Interned<dyn #trait_path> #where_clause {
-            fn from(value: &#ident #ty_generics) -> Self {
-                (value as &dyn #trait_path).into()
-            }
-        }
     })
     .into()
 }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -266,7 +266,7 @@ impl Plugin for RenderPlugin {
             app.init_resource::<ScratchMainWorld>();
 
             let mut render_app = App::empty();
-            render_app.main_schedule_label = Render.into();
+            render_app.main_schedule_label = Render.intern();
 
             let mut extract_schedule = Schedule::new();
             extract_schedule.set_apply_final_deferred(false);
@@ -405,7 +405,7 @@ fn extract(main_world: &mut World, render_app: &mut App) {
 fn apply_extract_commands(render_world: &mut World) {
     render_world.resource_scope(|render_world, mut schedules: Mut<Schedules>| {
         schedules
-            .get_mut(&ExtractSchedule)
+            .get_mut(ExtractSchedule)
             .unwrap()
             .apply_deferred(render_world);
     });

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -15,6 +15,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.12.0-dev", features = ["bevy_ref
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.12.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.12.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.12.0-dev", features = ["bevy"] }
+bevy_utils = { path = "../bevy_utils", version = "0.12.0-dev" }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/crates/bevy_utils/src/intern.rs
+++ b/crates/bevy_utils/src/intern.rs
@@ -22,10 +22,10 @@ use crate::HashSet;
 /// # Implementation details
 ///
 /// This is just a reference to a value with an `'static` lifetime.
-///
-/// This implements [`Copy`], [`Clone`], [`PartialEq`], [`Eq`] and [`Hash`] regardles of what `T`
-/// implements, because it only uses the pointer to the value and not the value itself.
-/// Therefore it MUST NEVER implement [`Borrow`](`std::borrow::Borrow`).
+//
+// This implements [`Copy`], [`Clone`], [`PartialEq`], [`Eq`] and [`Hash`] regardles of what `T`
+// implements, because it only uses the pointer to the value and not the value itself.
+// Therefore it MUST NEVER implement [`Borrow`](`std::borrow::Borrow`).
 pub struct Interned<T: ?Sized + 'static>(&'static T);
 
 impl<T: ?Sized> Deref for Interned<T> {

--- a/crates/bevy_utils/src/intern.rs
+++ b/crates/bevy_utils/src/intern.rs
@@ -26,7 +26,7 @@ use crate::HashSet;
 // This implements [`Copy`], [`Clone`], [`PartialEq`], [`Eq`] and [`Hash`] regardles of what `T`
 // implements, because it only uses the pointer to the value and not the value itself.
 // Therefore it MUST NEVER implement [`Borrow`](`std::borrow::Borrow`).
-pub struct Interned<T: ?Sized + 'static>(&'static T);
+pub struct Interned<T: ?Sized + 'static>(pub &'static T);
 
 impl<T: ?Sized> Deref for Interned<T> {
     type Target = T;

--- a/crates/bevy_utils/src/label.rs
+++ b/crates/bevy_utils/src/label.rs
@@ -156,6 +156,12 @@ macro_rules! define_label {
             }
         }
 
+        impl ::bevy_utils::intern::Leak for dyn $label_trait_name {
+            fn leak(&self) -> &'static Self {
+                Box::leak(self.dyn_clone())
+            }
+        }
+
         impl ::bevy_utils::intern::StaticRef for dyn $label_trait_name {
             fn static_ref(&self) -> std::option::Option<&'static dyn $label_trait_name> {
                 self.dyn_static_ref()
@@ -171,21 +177,7 @@ macro_rules! define_label {
             fn from(
                 value: &dyn $label_trait_name,
             ) -> ::bevy_utils::intern::Interned<dyn $label_trait_name> {
-                struct LeakHelper<'a>(&'a dyn $label_trait_name);
-
-                impl<'a> ::std::borrow::Borrow<dyn $label_trait_name> for LeakHelper<'a> {
-                    fn borrow(&self) -> &dyn $label_trait_name {
-                        self.0
-                    }
-                }
-
-                impl<'a> ::bevy_utils::intern::Leak<dyn $label_trait_name> for LeakHelper<'a> {
-                    fn leak(self) -> &'static dyn $label_trait_name {
-                        Box::leak(self.0.dyn_clone())
-                    }
-                }
-
-                $interner_name.intern(LeakHelper(value))
+                $interner_name.intern(value)
             }
         }
     };

--- a/crates/bevy_utils/src/label.rs
+++ b/crates/bevy_utils/src/label.rs
@@ -142,6 +142,29 @@ macro_rules! define_label {
             }
         }
 
+        impl $label_trait_name for ::bevy_utils::intern::Interned<dyn $label_trait_name> {
+            fn inner_type_id(&self) -> ::std::any::TypeId {
+                (**self).inner_type_id()
+            }
+
+            fn dyn_clone(&self) -> Box<dyn $label_trait_name> {
+                (**self).dyn_clone()
+            }
+
+            /// Casts this value to a form where it can be compared with other type-erased values.
+            fn as_dyn_eq(&self) -> &dyn ::bevy_utils::label::DynEq {
+                (**self).as_dyn_eq()
+            }
+
+            fn dyn_hash(&self, state: &mut dyn ::std::hash::Hasher) {
+                (**self).dyn_hash(state)
+            }
+
+            fn dyn_static_ref(&self) -> Option<&'static dyn $label_trait_name> {
+                Some(self.0)
+            }
+        }
+
         impl PartialEq for dyn $label_trait_name {
             fn eq(&self, other: &Self) -> bool {
                 self.as_dyn_eq().dyn_eq(other.as_dyn_eq())

--- a/crates/bevy_utils/src/label.rs
+++ b/crates/bevy_utils/src/label.rs
@@ -160,9 +160,7 @@ macro_rules! define_label {
             fn leak(&self) -> &'static Self {
                 Box::leak(self.dyn_clone())
             }
-        }
 
-        impl ::bevy_utils::intern::StaticRef for dyn $label_trait_name {
             fn static_ref(&self) -> std::option::Option<&'static dyn $label_trait_name> {
                 self.dyn_static_ref()
             }

--- a/crates/bevy_utils/src/label.rs
+++ b/crates/bevy_utils/src/label.rs
@@ -82,16 +82,6 @@ macro_rules! define_label {
 
         $(#[$label_attr])*
         pub trait $label_trait_name: 'static + Send + Sync + ::std::fmt::Debug {
-            /// Return's the [TypeId] of this label, or the the ID of the
-            /// wrappped label type for `Box<dyn
-            #[doc = stringify!($label_trait_name)]
-            /// >`
-            ///
-            /// [TypeId]: std::any::TypeId
-            fn inner_type_id(&self) -> ::std::any::TypeId {
-                std::any::TypeId::of::<Self>()
-            }
-
             /// Clones this `
             #[doc = stringify!($label_trait_name)]
             /// `
@@ -149,10 +139,6 @@ macro_rules! define_label {
         }
 
         impl $label_trait_name for ::bevy_utils::intern::Interned<dyn $label_trait_name> {
-            fn inner_type_id(&self) -> ::std::any::TypeId {
-                (**self).inner_type_id()
-            }
-
             fn dyn_clone(&self) -> Box<dyn $label_trait_name> {
                 (**self).dyn_clone()
             }

--- a/crates/bevy_utils/src/label.rs
+++ b/crates/bevy_utils/src/label.rs
@@ -140,6 +140,12 @@ macro_rules! define_label {
             fn dyn_static_ref(&self) -> Option<&'static dyn $label_trait_name> {
                 None
             }
+
+            /// Returns an `interned`(bevy_utils::intern::Interned) value corresponding to `self`.
+            fn intern(&self) -> ::bevy_utils::intern::Interned<dyn $label_trait_name>
+            where Self: Sized {
+                $interner_name.intern(self)
+            }
         }
 
         impl $label_trait_name for ::bevy_utils::intern::Interned<dyn $label_trait_name> {
@@ -191,15 +197,5 @@ macro_rules! define_label {
 
         static $interner_name: ::bevy_utils::intern::Interner<dyn $label_trait_name> =
             ::bevy_utils::intern::Interner::new();
-
-        impl From<&dyn $label_trait_name>
-            for ::bevy_utils::intern::Interned<dyn $label_trait_name>
-        {
-            fn from(
-                value: &dyn $label_trait_name,
-            ) -> ::bevy_utils::intern::Interned<dyn $label_trait_name> {
-                $interner_name.intern(value)
-            }
-        }
     };
 }

--- a/crates/bevy_utils/src/label.rs
+++ b/crates/bevy_utils/src/label.rs
@@ -155,6 +155,10 @@ macro_rules! define_label {
             fn dyn_static_ref(&self) -> Option<&'static dyn $label_trait_name> {
                 Some(self.0)
             }
+
+            fn intern(&self) -> Self {
+                *self
+            }
         }
 
         impl PartialEq for dyn $label_trait_name {


### PR DESCRIPTION
* Simplified the `Leak` trait, and merged `StaticRef` into it.
* Interned labels now implement their corresponding label traits, which simplifies their usage heavily.
* Added the `.intern()` method to the label traits, which makes interning them more ergonomic. This removes the syntax `InternedLabel::from(&label as &dyn Label)`.